### PR TITLE
shared store debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/**
+.idea

--- a/JXSessionStore.js
+++ b/JXSessionStore.js
@@ -20,6 +20,7 @@ module.exports = function(sess){
 		//console.log("get %s: %s", sessionId, JSON.stringify(session));
 		var err = null;
 		callback(err, session);
+    process.sendToThreads({ tid : process.threadId, sid : sessionId, cmd : "get" });
 	}
 
 	JXSessionStore.prototype.set = function(sessionId, session, callback){
@@ -29,7 +30,7 @@ module.exports = function(sess){
 		jxcore.store.shared.set(sessionId, JSON.stringify(session));
 		var err = null;
 		callback(err, session);
-    process.sendToThreads({ tid : process.threadId, sid : sessionId});
+    process.sendToThreads({ tid : process.threadId, sid : sessionId, cmd : "set" });
 	}
 
 	JXSessionStore.prototype.touch = function(sessionId, session, callback){

--- a/JXSessionStore.js
+++ b/JXSessionStore.js
@@ -29,6 +29,7 @@ module.exports = function(sess){
 		jxcore.store.shared.set(sessionId, JSON.stringify(session));
 		var err = null;
 		callback(err, session);
+    process.sendToThreads({ tid : process.threadId, sid : sessionId});
 	}
 
 	JXSessionStore.prototype.touch = function(sessionId, session, callback){

--- a/app.js
+++ b/app.js
@@ -15,7 +15,7 @@ HTTPSERVER.logic = function(serverID){
 		server = require('http').createServer(app);
 
   jxcore.tasks.on('message', function(tid, param) {
-    jxcore.utils.console.log("thread no", process.threadId, jxcore.store.shared.read(param.sid));
+    jxcore.utils.console.log("thread no", param.cmd, process.threadId, jxcore.store.shared.read(param.sid), param.cmd == "get" ? "green" : "yellow");
   });
 
 	app.use(new session({

--- a/app.js
+++ b/app.js
@@ -13,7 +13,11 @@ HTTPSERVER.define = function(){
 HTTPSERVER.logic = function(serverID){
 	var app = express(),
 		server = require('http').createServer(app);
-	
+
+  jxcore.tasks.on('message', function(tid, param) {
+    jxcore.utils.console.log("thread no", process.threadId, jxcore.store.shared.read(param.sid));
+  });
+
 	app.use(new session({
 		store: new JXSessionStore(),
 		cookie: {
@@ -35,9 +39,11 @@ HTTPSERVER.logic = function(serverID){
 		
 		res.end("done");
 	});
-	
-	server.listen(80, function(){
-		console.log("server %s (thread %s) listening on port 80", serverID, process.threadId);
+
+  var port = process.argv[2] || 80;
+
+	server.listen(port, function(){
+		console.log("server %s (thread %s) listening on port", port, serverID, process.threadId);
 	});
 }
 


### PR DESCRIPTION
This commit proves, that `jxcore.store.shared` works: once you'll call `localhost:port/set` or later `localhost:port`, all threads will read the value from store immediately and display into console, e.g.:

```bash
$ jxv8 app.js 8001
server 8001 (thread 0) listening on port 1
server 8001 (thread 1) listening on port 0
get on thread 1
set on thread 1
set on thread 1
thread no set 1 {"cookie":{"originalMaxAge":null,"expires":null,"secure":false,"httpOnly":true,"path":"/"},"test":"haii"}
thread no set 0 {"cookie":{"originalMaxAge":null,"expires":null,"secure":false,"httpOnly":true,"path":"/"},"test":"haii"}
get on thread 1
get on thread 1
set on thread 1
thread no set 0 {"cookie":{"originalMaxAge":null,"expires":null,"secure":false,"httpOnly":true,"path":"/"},"test":"haii"}
thread no set 1 {"cookie":{"originalMaxAge":null,"expires":null,"secure":false,"httpOnly":true,"path":"/"},"test":"haii"}
thread no get 1 {"cookie":{"originalMaxAge":null,"expires":null,"secure":false,"httpOnly":true,"path":"/"},"test":"haii"}
thread no get 0 {"cookie":{"originalMaxAge":null,"expires":null,"secure":false,"httpOnly":true,"path":"/"},"test":"haii"}
``` 